### PR TITLE
Fix TagInput container reassignment

### DIFF
--- a/src/js/components/App.js
+++ b/src/js/components/App.js
@@ -229,7 +229,7 @@ export class App extends BaseComponent {
         // Initialize TagInput component with longer delay and better error handling
         setTimeout(() => {
             try {
-                const tagInputContainer = document.querySelector('#keywordTagInput');
+                let tagInputContainer = document.querySelector('#keywordTagInput');
                 if (!tagInputContainer) {
                     debugLog('❌ TagInput container not found, trying fallback selectors...');
                     // Try fallback selectors


### PR DESCRIPTION
## Summary
- allow `tagInputContainer` to be reassigned when fallback elements are found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6846111e788883258625934b2bd0d399