### PR TITLE
Fix mode retrieval from global state

### DIFF
--- a/src/js/utils/environment.js
+++ b/src/js/utils/environment.js
@@ -3,7 +3,7 @@
  * Unified: Local development identical to GitHub Pages with auto-loaded API keys
  */
 
-import { CONFIG, updateGlobalState } from '../config.js';
+import { CONFIG, updateGlobalState, getGlobalState } from '../config.js';
 import { debugLog } from './debug.js';
 
 /**
@@ -120,7 +120,7 @@ function initializeGitHubPages() {
  * @returns {string} Current mode: 'demo', 'live', or 'local-auto'
  */
 export function getCurrentMode() {
-    return CONFIG.GLOBAL_STATE?.apiMode || 'demo';
+    return getGlobalState('apiMode') || 'demo';
 }
 
 /**


### PR DESCRIPTION
## Summary
- import `getGlobalState` in environment utils
- read the current API mode from the global state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68461120cb3c8325b76592070f1f504c