### PR TITLE
Update integration test for API key validation

### DIFF
--- a/src/js/integration-test.js
+++ b/src/js/integration-test.js
@@ -87,7 +87,7 @@ export class IntegrationTest {
         
         this.test('Security utilities work', () => {
             return sanitizeURL('javascript:alert(1)') === '' &&
-                   validateApiKey('AIza1234567890123456789012345') === true;
+                   validateApiKey('AIza1234567890123456789012345').valid === true;
         });
         
         // Test 5: Service Initialization


### PR DESCRIPTION
## Summary
- update integration test to expect `validateApiKey()` to return an object with a `valid` flag

## Testing
- `npm run test:node` *(fails: Environment detection and DOM dependent tests fail)*

------
https://chatgpt.com/codex/tasks/task_b_6846112cb278832590790844242362c5